### PR TITLE
Add secondary, smaller Character Count Warning for dialogue lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ McSlinky-linux-x64
 McSlinky_windows.zip
 ReleaseUpload
 app/renderer/documentation/
+.DS_Store
+npm-debug.log

--- a/app/main-process/main.js
+++ b/app/main-process/main.js
@@ -131,8 +131,8 @@ app.on('ready', function () {
     }
 
     settings.defaults({
-        charCountDanger: 140,
-        dialogueCountDanger: 75,
+        narrativeCountDanger: 140,
+        dialogCountDanger: 75,
         charCountCutoff: 560,
         enforceCharCounts: true
     });

--- a/app/main-process/main.js
+++ b/app/main-process/main.js
@@ -132,6 +132,7 @@ app.on('ready', function () {
 
     settings.defaults({
         charCountDanger: 75,
+        dialogueCountDanger: 25,
         charCountCutoff: 560,
         enforceCharCounts: true
     });

--- a/app/main-process/main.js
+++ b/app/main-process/main.js
@@ -131,8 +131,8 @@ app.on('ready', function () {
     }
 
     settings.defaults({
-        charCountDanger: 75,
-        dialogueCountDanger: 25,
+        charCountDanger: 140,
+        dialogueCountDanger: 75,
         charCountCutoff: 560,
         enforceCharCounts: true
     });

--- a/app/prefs/controller.js
+++ b/app/prefs/controller.js
@@ -15,8 +15,9 @@ $(document).ready(() => {
 
   /* for reference; these are declared in main.js
       settings.defaults({
-        charCountDanger: 90,
-        charCountCutoff: 120,
+        narrativeCountDanger: 140,
+        dialogCountDanger: 75,
+        charCountCutoff: 560,
         enforceCharCounts: true
     });
   */
@@ -75,4 +76,3 @@ $(document).ready(() => {
   });
 
 });
-

--- a/app/renderer/main.css
+++ b/app/renderer/main.css
@@ -650,6 +650,18 @@ img.issue-icon.warning {
   background-color: #FFDC00;
 }
 
+#player p .characterName {
+  color: #A0522D;
+}
+
+#player p .Lina::before {
+  content: '👩🏽‍🎤 ';
+}
+
+#player p .notLina::before {
+  content: '👤 ';
+}
+
 #player span.carrotTags {
   color: #AAA;
   font-family: monospace;

--- a/app/renderer/main.css
+++ b/app/renderer/main.css
@@ -651,15 +651,11 @@ img.issue-icon.warning {
 }
 
 #player p .characterName {
-  color: #A0522D;
+  color: #8e5d0e;
 }
 
-#player p .Lina::before {
-  content: '👩🏽‍🎤 ';
-}
-
-#player p .notLina::before {
-  content: '👤 ';
+#player p .characterName.Lina {
+  color: #1D0C6F;
 }
 
 #player span.carrotTags {

--- a/app/renderer/playerView.js
+++ b/app/renderer/playerView.js
@@ -133,16 +133,14 @@ function addTextSection(text)
         let charCount = 0;
         const MAX_NARRATION_COUNT = settings.getSync("narrativeCountDanger");
         const MAX_DIALOGUE_COUNT = settings.getSync("dialogCountDanger");
+        let dangerousWordCount = isDialogueLine ? MAX_DIALOGUE_COUNT : MAX_NARRATION_COUNT;
 
-        console.log(MAX_NARRATION_COUNT, MAX_DIALOGUE_COUNT, arrayOfWords)
-        const dangerousWordCount = isDialogueLine ? MAX_DIALOGUE_COUNT : MAX_NARRATION_COUNT;
         for (var i = 0; i < arrayOfWords.length; i++) {
           var currentWord = arrayOfWords[i];
           charCount += currentWord.length;
           if (charCount < dangerousWordCount) {
               plainSpans.push(currentWord);
           } else {
-            console.log (currentWord, charCount, dangerousWordCount);
             highlightedSpans.push(currentWord);
           }
         }
@@ -151,9 +149,9 @@ function addTextSection(text)
         plainSpans = arrayOfWords;
     }
 
-    var isLina = (arrayOfWords[0] === 'LINA:');
-
+    let isLina = (arrayOfWords[0] === 'LINA:');
     let initialSpan = "<span>";
+    
     if (isDialogueLine && isLina) {
       initialSpan = "<span class='characterName Lina'>‍"
     } else if (isDialogueLine) {

--- a/app/renderer/playerView.js
+++ b/app/renderer/playerView.js
@@ -139,7 +139,7 @@ function addTextSection(text)
           var currentWord = arrayOfWords[i];
           charCount += currentWord.length;
           if (charCount < dangerousWordCount) {
-              plainSpans.push(currentWord);
+            plainSpans.push(currentWord);
           } else {
             highlightedSpans.push(currentWord);
           }
@@ -155,7 +155,7 @@ function addTextSection(text)
     if (isDialogueLine && isLina) {
       initialSpan = "<span class='characterName Lina'>‍"
     } else if (isDialogueLine) {
-      initialSpan = "<span class='characterName notLina'>"
+      initialSpan = "<span class='characterName'>"
     }
 
     var textAsSpans = initialSpan + plainSpans.join("</span> <span>") + "</span>";

--- a/app/renderer/playerView.js
+++ b/app/renderer/playerView.js
@@ -131,8 +131,10 @@ function addTextSection(text)
     if (settings.getSync("enforceCharCounts")) {
         // ROBIN: Enforce character counts on this <p>.
         let charCount = 0;
-        const MAX_NARRATION_COUNT = settings.getSync("charCountDanger");
-        const MAX_DIALOGUE_COUNT = settings.getSync("dialogueCountDanger");
+        const MAX_NARRATION_COUNT = settings.getSync("narrativeCountDanger");
+        const MAX_DIALOGUE_COUNT = settings.getSync("dialogCountDanger");
+
+        console.log(MAX_NARRATION_COUNT, MAX_DIALOGUE_COUNT, arrayOfWords)
         const dangerousWordCount = isDialogueLine ? MAX_DIALOGUE_COUNT : MAX_NARRATION_COUNT;
         for (var i = 0; i < arrayOfWords.length; i++) {
           var currentWord = arrayOfWords[i];
@@ -140,7 +142,8 @@ function addTextSection(text)
           if (charCount < dangerousWordCount) {
               plainSpans.push(currentWord);
           } else {
-              highlightedSpans.push(currentWord);
+            console.log (currentWord, charCount, dangerousWordCount);
+            highlightedSpans.push(currentWord);
           }
         }
     } else {
@@ -156,7 +159,7 @@ function addTextSection(text)
     } else if (isDialogueLine) {
       initialSpan = "<span class='characterName notLina'>"
     }
-    
+
     var textAsSpans = initialSpan + plainSpans.join("</span> <span>") + "</span>";
 
     if (highlightedSpans.length > 0) {

--- a/app/renderer/playerView.js
+++ b/app/renderer/playerView.js
@@ -107,6 +107,7 @@ function addTextSection(text)
     // Split the line if we have a >>
     var splitOnCarrotTags = text.split(">>");
     var nonTagText = splitOnCarrotTags.shift();
+
     // Reconstitute the rest of the line that has tags
     var tagText = "";
     if (splitOnCarrotTags.length > 0) {
@@ -114,34 +115,50 @@ function addTextSection(text)
     }
 
     // If all we have left is a character name, style that like a tag
+
     if (/[A-Z]+:\s*$/.test(nonTagText)) {
         tagText = nonTagText + tagText;
         nonTagText = "";
     }
 
-    var splitIntoSpans = nonTagText.split(" ");
+    var arrayOfWords = nonTagText.split(" ");
+    var dialogueRegex = /^[A-Z]+:/
+    var isDialogueLine = dialogueRegex.test(arrayOfWords[0]);
 
-    var plainSpans = new Array();
-    var highlightedSpans = new Array();
+    var plainSpans = [];
+    var highlightedSpans = [];
 
     if (settings.getSync("enforceCharCounts")) {
         // ROBIN: Enforce character counts on this <p>.
         let charCount = 0;
-        let charCutoff = settings.getSync("charCountDanger");
-        for (let span of splitIntoSpans) {
-            charCount += span.length;
-            if (charCount < charCutoff) {
-                plainSpans.push(span);
-            } else {
-                highlightedSpans.push(span);
-            }
+        const MAX_NARRATION_COUNT = settings.getSync("charCountDanger");
+        const MAX_DIALOGUE_COUNT = settings.getSync("dialogueCountDanger");
+        const dangerousWordCount = isDialogueLine ? MAX_DIALOGUE_COUNT : MAX_NARRATION_COUNT;
+        for (var i = 0; i < arrayOfWords.length; i++) {
+          var currentWord = arrayOfWords[i];
+          charCount += currentWord.length;
+          if (charCount < dangerousWordCount) {
+              plainSpans.push(currentWord);
+          } else {
+              highlightedSpans.push(currentWord);
+          }
         }
     } else {
         // ROBIN: We are not enforcing any character counts, so...
-        plainSpans = splitIntoSpans;
+        plainSpans = arrayOfWords;
     }
 
-    var textAsSpans = "<span>" + plainSpans.join("</span> <span>") + "</span>";
+    var isLina = (arrayOfWords[0] === 'LINA:');
+
+    let initialSpan = "<span>";
+    if (isDialogueLine && isLina) {
+      initialSpan = "<span class='characterName Lina'>‍"
+    } else if (isDialogueLine) {
+      initialSpan = "<span class='characterName notLina'>"
+    }
+    
+    var textAsSpans = initialSpan + plainSpans.join("</span> <span>") + "</span>";
+
     if (highlightedSpans.length > 0) {
         // ROBIN: Note the space at the front here. Fussy.
         textAsSpans += " <span class='charCountWarning'>" + highlightedSpans.join("</span> <span class='charCountWarning'>") + "</span>";


### PR DESCRIPTION
Adds a second character count for dialogue vs. narrative lines. Applies dialogue check to dialogue lines (determined by regex). 

For dialogue lines, changes styling of the character name for emphasis.


<img width="522" alt="screen shot 2018-01-15 at 9 29 16 pm" src="https://user-images.githubusercontent.com/693891/34973194-4d43a2da-fa3b-11e7-8eaa-054188347f4c.png">
