### PR TITLE
Updated choice style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ McSlinky-linux-x64
 McSlinky_windows.zip
 ReleaseUpload
 app/renderer/documentation/
+.DS_Store
+npm-debug.log

--- a/app/renderer/main.css
+++ b/app/renderer/main.css
@@ -656,24 +656,23 @@ img.issue-icon.warning {
   padding-left: 15%;
 }
 
-#player p.choice span.carrotTags {
-  flex-basis: 40%;
-
-}
-
-
 #player p .charCountWarning {
   background-color: #FFDC00;
+}
+#player div.tagContainer {
+  flex-basis: 40%;
+  float: right;
+  max-width: 40%;
+  text-align: right;
 }
 
 #player span.carrotTags {
   // color: #AAA;
   color: #555;
-  background-color: #b8b6b8;
+  border-radius: 2px;
+  background-color: #f5f5f4;
   font-family: monospace;
-  float: right;
-  width: 40%;
-  text-align: right;
+  padding:2px;
 }
 
 #main.hideTags #player span.carrotTags {

--- a/app/renderer/main.css
+++ b/app/renderer/main.css
@@ -641,17 +641,35 @@ img.issue-icon.warning {
   text-decoration: underline;
 }
 
+
 /* MCSLINKY ADDITIONS */
 #player p {
     clear: right;
 }
+
+#player p.choice {
+    display: flex;
+}
+
+#player p.choice a {
+  flex-basis: 60%;
+  padding-left: 15%;
+}
+
+#player p.choice span.carrotTags {
+  flex-basis: 40%;
+
+}
+
 
 #player p .charCountWarning {
   background-color: #FFDC00;
 }
 
 #player span.carrotTags {
-  color: #AAA;
+  // color: #AAA;
+  color: #555;
+  background-color: #b8b6b8;
   font-family: monospace;
   float: right;
   width: 40%;

--- a/app/renderer/main.css
+++ b/app/renderer/main.css
@@ -626,10 +626,6 @@ img.issue-icon.warning {
   margin: 0 auto;
 }
 
-#player p.choice {
-  text-align: center;
-}
-
 #player p.choice a {
   color: #BBB;
   transition: color 0.2s;
@@ -647,32 +643,28 @@ img.issue-icon.warning {
     clear: right;
 }
 
-#player p.choice {
-    display: flex;
+#player p.choice a {
+  color: #555;
+  border-radius: 3px;
+  background-color: #f5f5f4;
+  padding: 4px;
+  display:inline-block;
 }
 
-#player p.choice a {
-  flex-basis: 60%;
-  padding-left: 15%;
+#player .choiceOption {
+  padding-left: 5%;
 }
 
 #player p .charCountWarning {
   background-color: #FFDC00;
 }
-#player div.tagContainer {
-  flex-basis: 40%;
+
+#player span.carrotTags {
   float: right;
   max-width: 40%;
   text-align: right;
-}
-
-#player span.carrotTags {
-  // color: #AAA;
-  color: #555;
-  border-radius: 2px;
-  background-color: #f5f5f4;
+  color: #AAA;
   font-family: monospace;
-  padding:2px;
 }
 
 #main.hideTags #player span.carrotTags {

--- a/app/renderer/playerView.js
+++ b/app/renderer/playerView.js
@@ -147,7 +147,7 @@ function addTextSection(text)
         textAsSpans += " <span class='charCountWarning'>" + highlightedSpans.join("</span> <span class='charCountWarning'>") + "</span>";
     }
     if (tagText.length > 0) {
-        textAsSpans += ` <span class='carrotTags'>${tagText}</span`;
+        textAsSpans += ` <div class='tagContainer'><span class='carrotTags'>${tagText}</span</div>`;
     }
 
     $paragraph.html(textAsSpans);
@@ -216,7 +216,7 @@ function addChoice(choice, callback)
     if (carrotIndex != -1) {
         let tagText = text.substr(carrotIndex);
         text = text.substr(0, carrotIndex);
-        $tags = $(`<span class='carrotTags'>${tagText}</span>`);
+        $tags = $(`<div class='tagContainer'><span class='carrotTags'>${tagText}</span></div>`);
     }
     var $choice = $("<a href='#'>"+text+"</a>");
 

--- a/app/renderer/playerView.js
+++ b/app/renderer/playerView.js
@@ -147,7 +147,7 @@ function addTextSection(text)
         textAsSpans += " <span class='charCountWarning'>" + highlightedSpans.join("</span> <span class='charCountWarning'>") + "</span>";
     }
     if (tagText.length > 0) {
-        textAsSpans += ` <div class='tagContainer'><span class='carrotTags'>${tagText}</span</div>`;
+        textAsSpans += ` <span class='carrotTags'>${tagText}</span`;
     }
 
     $paragraph.html(textAsSpans);
@@ -216,9 +216,9 @@ function addChoice(choice, callback)
     if (carrotIndex != -1) {
         let tagText = text.substr(carrotIndex);
         text = text.substr(0, carrotIndex);
-        $tags = $(`<div class='tagContainer'><span class='carrotTags'>${tagText}</span></div>`);
+        $tags = $(`<span class='carrotTags'>${tagText}</span>`);
     }
-    var $choice = $("<a href='#'>"+text+"</a>");
+    var $choice = $("<span class='choiceOption'><a href='#'>"+text+"</a></span>");
 
     // Append the choice
     var $choicePara = $("<p class='choice'></p>");


### PR DESCRIPTION
To fix issues with choices not being centered (due to lines with tags), updated the choice styling.

Got some feedback from hoverbird. End style is having choice text emphasized with background coloring, and left-aligned with slight padding.


<img width="627" alt="screen shot 2018-01-15 at 9 33 07 pm" src="https://user-images.githubusercontent.com/693891/34973278-bb709b64-fa3b-11e7-9708-85eccfbb350e.png">
